### PR TITLE
Simplify instructions and example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,45 +1,33 @@
 # On Ubuntu 18.04, get the latest CMake from https://apt.kitware.com/.
 cmake_minimum_required(VERSION 3.18)
-set(CMAKE_CXX_STANDARD 14)
-project(Open3DCMakeFindPackage LANGUAGES C CXX)
 
-if(POLICY CMP0091)
-    # https://stackoverflow.com/a/56490614
-    cmake_policy(SET CMP0091 NEW)
-endif()
+project(Open3DCMakeFindPackage LANGUAGES C CXX)
 
 # The options need to be the same as Open3D's default
 # If Open3D is configured and built with custom options, you'll also need to
 # specify the same custom options.
 option(STATIC_WINDOWS_RUNTIME "Use static (MT/MTd) Windows runtime" ON)
-# This needs cmake_policy(SET CMP0091 NEW)
-if (STATIC_WINDOWS_RUNTIME)
+if(STATIC_WINDOWS_RUNTIME)
     set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 else()
     set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
 endif()
 
 # Find installed Open3D, which exports Open3D::Open3D
-if(WIN32)
-    find_package(Open3D HINTS ${CMAKE_INSTALL_PREFIX}/CMake)
-else()
-    find_package(Open3D HINTS ${CMAKE_INSTALL_PREFIX}/lib/cmake)
-endif()
-if(NOT Open3D_FOUND)
-    message(FATAL_ERROR "Open3D not found, please use -DCMAKE_INSTALL_PREFIX=open3d_install_dir")
-endif()
+find_package(Open3D REQUIRED)
 
-add_executable(Draw Draw.cpp)
-target_link_libraries(Draw Open3D::Open3D)
+add_executable(Draw)
+target_sources(Draw PRIVATE Draw.cpp)
+target_link_libraries(Draw PRIVATE Open3D::Open3D)
 
-# On Windows, when BUILD_SHARED_LIBS, copy .dll to the executable directory
+# On Windows if BUILD_SHARED_LIBS is enabled, copy .dll files to the executable directory
 if(WIN32)
     get_target_property(open3d_type Open3D::Open3D TYPE)
     if(open3d_type STREQUAL "SHARED_LIBRARY")
-        message(STATUS "Will copy Open3D.dll to ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>")
+        message(STATUS "Copying Open3D.dll to ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>")
         add_custom_command(TARGET Draw POST_BUILD
-                        COMMAND ${CMAKE_COMMAND} -E copy
-                                ${CMAKE_INSTALL_PREFIX}/bin/Open3D.dll
-                                ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>)
+                           COMMAND ${CMAKE_COMMAND} -E copy
+                                   ${CMAKE_INSTALL_PREFIX}/bin/Open3D.dll
+                                   ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>)
     endif()
 endif()

--- a/Draw.cpp
+++ b/Draw.cpp
@@ -29,19 +29,17 @@
 #include "open3d/Open3D.h"
 
 int main(int argc, char *argv[]) {
-    using namespace open3d;
-
     if (argc == 2) {
         std::string option(argv[1]);
         if (option == "--skip-for-unit-test") {
-            utility::LogInfo("Skiped for unit test.");
+            open3d::utility::LogInfo("Skiped for unit test.");
             return 0;
         }
     }
 
-    auto sphere = geometry::TriangleMesh::CreateSphere(1.0);
+    auto sphere = open3d::geometry::TriangleMesh::CreateSphere(1.0);
     sphere->ComputeVertexNormals();
     sphere->PaintUniformColor({0.0, 1.0, 0.0});
-    visualization::DrawGeometries({sphere});
+    open3d::visualization::DrawGeometries({sphere});
     return 0;
 }

--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@ For more details, check out the [Open3D repo](https://github.com/intel-isl/Open3
 
 Follow the [Open3D compilation guide](http://www.open3d.org/docs/release/compilation.html),
 compile and install Open3D in your preferred location. You can specify the
-installation path with `CMAKE_INSTALL_PREFIX`. E.g.
+installation path with `CMAKE_INSTALL_PREFIX` and the number of parallel jobs
+to speed up compilation.
 
-On Ubuntu/MacOS:
+On Ubuntu/macOS:
 
 ```bash
 git clone --recursive https://github.com/intel-isl/Open3D.git
@@ -23,6 +24,7 @@ cd Open3D
 mkdir build
 cd build
 cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=${HOME}/open3d_install ..
+cmake --build . --config Release --parallel 12 --target install
 cd ../..
 ```
 
@@ -33,8 +35,8 @@ git clone --recursive https://github.com/intel-isl/Open3D.git
 cd Open3D
 mkdir build
 cd build
-cmake -G "Visual Studio 16 2019 Win64" -A x64 -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=C:\open3d_install ..
-cmake --build . --config Release --target install
+cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=C:\open3d_install ..
+cmake --build . --config Release --parallel 12 --target install
 cd ..\..
 ```
 
@@ -42,14 +44,15 @@ Note: `-DBUILD_SHARED_LIBS=ON` is recommended if `-DBUILD_CUDA_MODULE=ON`.
 
 ## Step 2: Use Open3D in this example project
 
-On Ubuntu/MacOS:
+On Ubuntu/macOS:
 
 ```bash
 git clone https://github.com/intel-isl/open3d-cmake-find-package.git
 cd open3d-cmake-find-package
 mkdir build
 cd build
-cmake -DCMAKE_INSTALL_PREFIX=${HOME}/open3d_install ..
+cmake -DOpen3D_ROOT=${HOME}/open3d_install ..
+cmake --build . --config Release
 ./Draw
 ```
 
@@ -59,7 +62,7 @@ On Windows:
 git clone https://github.com/intel-isl/open3d-cmake-find-package.git
 cd open3d-cmake-find-package
 mkdir build
-cmake -G "Visual Studio 16 2019 Win64" -A x64 -DCMAKE_PREFIX_PATH=C:\open3d_install ..
+cmake -DOpen3D_ROOT=C:\open3d_install ..
 cmake --build . --config Release
 Release\Draw
 ```


### PR DESCRIPTION
- Remove explicit setting of CMake policy `0091` and `CMAKE_CXX_STANDARD` as they are already automatically handled
- Simplify `find_package` call as CMake automatically searches in these paths
- Use `target_sources` and always specify the scope (e.g. `PRIVATE`) to encourage modern CMake 
- Remove `using namespace open3d` to discourage this bad practice
- Fix missing build step in Ubuntu/macOS instructions
- Add `--parallel` to show cross-platform multi-threaded builds
- Use `Open3D_ROOT` as the modern way to specify installation paths of libraries
- Remove `-G "Visual Studio 16 2019 Win64" -A x64` as this is already the default configuration for Visual Studio 2019